### PR TITLE
feat: Make article previews link to and render full stories on detail page

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import './App.css';
 import mockData from '../../mock-data.js';
 import Home from '../Home/Home';
+import ArticleDetail from '../ArticleDetail/ArticleDetail.jsx'
 
 function App() {
   const [ articles, setArticles ] = useState(mockData);
@@ -11,7 +12,7 @@ function App() {
     <main className="App">
       <Routes>
         <Route path='/' element={<Home articles={articles}/>} />
-        {/* <Route path='/somepath/:prop' element={anotherElement} /> */}
+        <Route path='/:index' element={<ArticleDetail articles={articles} />} />
 	    </Routes>
     </main>
   );

--- a/src/components/ArticleDetail/ArticleDetail.jsx
+++ b/src/components/ArticleDetail/ArticleDetail.jsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { v4 as uuid } from "uuid";
+import './ArticleDetail.css';
+
+const ArticleDetail = ({ articles, defaultIndex }) => {
+  const { index } = useParams();
+  const [selectedArticle, setSelectedArticle] = useState(null);
+  const [formattedContent, setFormattedContent] = useState('');
+
+  useEffect(() => {
+    const articleIndex = parseInt(index, 10);
+
+    if (!isNaN(articleIndex) && articleIndex >= 0 && articleIndex < articles.length) {
+      const initialContent = articles[articleIndex].content;
+
+      const pattern = /Comment on this story[\r\n\s]+Comment[\r\n\s]+Add to your saved stories[\r\n\s]+Save/g
+
+      const formattedContent = initialContent ? initialContent.replace(pattern, '') : '';
+
+      setSelectedArticle(articles[articleIndex]);
+      setFormattedContent(formattedContent);
+    }
+  }, [index, articles]);
+
+  return (
+    <div className='ArticleDetail'>
+      {selectedArticle && (
+        <>
+          <img className='preview-image' src={selectedArticle.urlToImage} alt={selectedArticle.title} />
+          <h2>{selectedArticle.title}</h2>
+          <p>{selectedArticle.publishedAt}</p>
+          <Link className='link-out' to={selectedArticle.url} target="_blank" key={uuid()} >
+            <p>{selectedArticle.source.name}</p>
+          </Link>
+          <p>{formattedContent}</p>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ArticleDetail;

--- a/src/components/ArticlePreview/ArticlePreview.jsx
+++ b/src/components/ArticlePreview/ArticlePreview.jsx
@@ -6,7 +6,7 @@ const ArticlePreview = ({ date, title, description, imageUrl, source }) => {
       <img className='preview-image' src={imageUrl} alt={title} />
       <h2>{title}</h2>
       <p>{date}</p>
-      <p>{source.name}</p>
+      {/* <p>{source.name}</p> */}
       <p>{description}</p>
     </div>
   );

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,17 +1,28 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { v4 as uuid } from "uuid";
 import './Home.css';
 import ArticlePreview from '../ArticlePreview/ArticlePreview';
 
 const Home = ({ articles }) => {
-  const articleCards = articles.map(article => (
-    <ArticlePreview
+  const [selectedArticle, setSelectedArticle] = useState(null);
+
+  const selectArticle = (selectedArticle) => {
+    setSelectedArticle(selectedArticle);
+  };
+
+  const articleCards = articles.map((article, index) => (
+    <Link className='article-link' to={`/${index}`} key={uuid()}>
+      <ArticlePreview
       key={uuid()}
       date={article.publishedAt}
       title={article.title}
       description={article.description}
       imageUrl={article.urlToImage}
       source={article.source}
-    />
+      onClick={() => selectArticle(selectedArticle)}
+      />
+    </Link>
   ));
 
 


### PR DESCRIPTION
# Description
- Add Links to ArticlePreviews
- Render full story details on detail page
- Format content to filter out comments, save, etc
- Adds link out to actual full story

# Screenshot(s)
<img width="1070" alt="Screenshot 2024-01-24 at 12 57 28 PM" src="https://github.com/ericahagle/mod4-take-home-challenge/assets/133910120/22e17b8f-6ef9-4756-bbf2-8b14b3ca3b4d">

# Notes
- Even though the spec says that linking out to the source story isn't enough, I feel the need to ALSO link out to the source stories, because the 'content' that is returned doesn't actually have the whole story. Each is truncated to only 200 characters, so the user doesn't get any more information than they did with just the description.

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] feat: My PR clearly describes the feature I'm adding.
